### PR TITLE
Ignoring query string

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,13 +13,21 @@ module.exports = function(port){
   http.createServer(function(req,res){
     if(req.method === 'GET') { 
       console.time('request');
-      filed('.' + req.url).pipe(res); 
+      var url = stripQS(req.url);
+      filed('.' + url).pipe(res); 
       console.timeEnd('request');
-      console.log((new Date()).toString() + ' - REQUESTED...' + req.url);
+      console.log((new Date()).toString() + ' - REQUESTED...' + url);
     } else {
       console.log((new Date()).toString() + ' - INVALID REQUEST... ONLY GET REQUESTS SUPPORTED');
     }
   }).listen(port, function(){
     console.log('w3 server listening on port -> ' + port.toString() + '\nctrl-c to exit');
   });
+}
+
+function stripQS(url){
+  var pos = url.indexOf('?');
+  return pos>-1 ?
+    url.substring(0, pos) : 
+    url;
 }


### PR DESCRIPTION
I'm using RequireJs with a parameter to force no cache, but that didn't work with w3 because the url was passed to filed with the querystring included, so I just remove it.
